### PR TITLE
Implement StorageTZ Attribute for DateTime with IncludeTimeValue

### DIFF
--- a/Camlex.NET.UnitTests/Factories/OperandBuilderTests.cs
+++ b/Camlex.NET.UnitTests/Factories/OperandBuilderTests.cs
@@ -144,6 +144,7 @@ namespace CamlexNET.UnitTests.Factories
             Assert.That(valueOperand.Type, Is.EqualTo(typeof(DataTypes.DateTime)));
             Assert.That(valueOperand.Value, Is.EqualTo(new DateTime(2010, 1, 2, 3, 4, 5)));
             Assert.That(valueOperand.IncludeTimeValue, Is.False);
+            Assert.That(valueOperand.StorageTZ, Is.False);
         }
 
         [Test]
@@ -162,6 +163,38 @@ namespace CamlexNET.UnitTests.Factories
         }
 
         [Test]
+        public void test_WHEN_native_value_is_datetime_with_includetimevalue_and_storagetz_true_THEN_datetime_operand_is_created()
+        {
+            var operandBuilder = new OperandBuilder();
+            Expression<Func<SPListItem, bool>> expr = x => (DateTime)x["Foo"] == new DateTime(2010, 1, 2, 3, 4, 5).IncludeTimeValue(true);
+            var operand = operandBuilder.CreateValueOperandForNativeSyntax(((BinaryExpression)expr.Body).Right);
+
+            Assert.That(operand, Is.InstanceOf<DateTimeValueOperand>());
+
+            var valueOperand = operand as DateTimeValueOperand;
+            Assert.That(valueOperand.Type, Is.EqualTo(typeof(DataTypes.DateTime)));
+            Assert.That(valueOperand.Value, Is.EqualTo(new DateTime(2010, 1, 2, 3, 4, 5)));
+            Assert.That(valueOperand.IncludeTimeValue, Is.True);
+            Assert.That(valueOperand.StorageTZ, Is.True);
+        }
+
+        [Test]
+        public void test_WHEN_native_value_is_datetime_with_includetimevalue_and_storagetz_false_THEN_datetime_operand_is_created()
+        {
+            var operandBuilder = new OperandBuilder();
+            Expression<Func<SPListItem, bool>> expr = x => (DateTime)x["Foo"] == new DateTime(2010, 1, 2, 3, 4, 5).IncludeTimeValue(false);
+            var operand = operandBuilder.CreateValueOperandForNativeSyntax(((BinaryExpression)expr.Body).Right);
+
+            Assert.That(operand, Is.InstanceOf<DateTimeValueOperand>());
+
+            var valueOperand = operand as DateTimeValueOperand;
+            Assert.That(valueOperand.Type, Is.EqualTo(typeof(DataTypes.DateTime)));
+            Assert.That(valueOperand.Value, Is.EqualTo(new DateTime(2010, 1, 2, 3, 4, 5)));
+            Assert.That(valueOperand.IncludeTimeValue, Is.True);
+            Assert.That(valueOperand.StorageTZ, Is.False);
+        }
+
+        [Test]
         public void test_WHEN_string_based_value_is_datetime_THEN_datetime_operand_is_created()
         {
             var operandBuilder = new OperandBuilder();
@@ -175,6 +208,7 @@ namespace CamlexNET.UnitTests.Factories
             var expected = DateTime.Parse("02.01.2010 03:04:05");
             Assert.That(valueOperand.Value, Is.EqualTo(expected));
             Assert.That(valueOperand.IncludeTimeValue, Is.False);
+            Assert.That(valueOperand.StorageTZ, Is.False);
         }
 
         [Test]
@@ -191,6 +225,40 @@ namespace CamlexNET.UnitTests.Factories
             var expected = DateTime.Parse("02.01.2010 03:04:05");
             Assert.That(valueOperand.Value, Is.EqualTo(expected));
             Assert.That(valueOperand.IncludeTimeValue, Is.True);
+        }
+
+        [Test]
+        public void test_WHEN_string_based_value_is_datetime_with_includetimevalue_and_storagetz_true_THEN_datetime_operand_is_created()
+        {
+            var operandBuilder = new OperandBuilder();
+            Expression<Func<SPListItem, bool>> expr = x => x["Modified"] == ((DataTypes.DateTime)"02.01.2010 03:04:05").IncludeTimeValue(true);
+            var operand = operandBuilder.CreateValueOperandForStringBasedSyntax(((BinaryExpression)expr.Body).Right);
+
+            Assert.That(operand, Is.InstanceOf<DateTimeValueOperand>());
+
+            var valueOperand = operand as DateTimeValueOperand;
+            Assert.That(valueOperand.Type, Is.EqualTo(typeof(DataTypes.DateTime)));
+            var expected = DateTime.Parse("02.01.2010 03:04:05");
+            Assert.That(valueOperand.Value, Is.EqualTo(expected));
+            Assert.That(valueOperand.IncludeTimeValue, Is.True);
+            Assert.That(valueOperand.StorageTZ, Is.True);
+        }
+
+        [Test]
+        public void test_WHEN_string_based_value_is_datetime_with_includetimevalue_and_storagetz_false_THEN_datetime_operand_is_created()
+        {
+            var operandBuilder = new OperandBuilder();
+            Expression<Func<SPListItem, bool>> expr = x => x["Modified"] == ((DataTypes.DateTime)"02.01.2010 03:04:05").IncludeTimeValue(false);
+            var operand = operandBuilder.CreateValueOperandForStringBasedSyntax(((BinaryExpression)expr.Body).Right);
+
+            Assert.That(operand, Is.InstanceOf<DateTimeValueOperand>());
+
+            var valueOperand = operand as DateTimeValueOperand;
+            Assert.That(valueOperand.Type, Is.EqualTo(typeof(DataTypes.DateTime)));
+            var expected = DateTime.Parse("02.01.2010 03:04:05");
+            Assert.That(valueOperand.Value, Is.EqualTo(expected));
+            Assert.That(valueOperand.IncludeTimeValue, Is.True);
+            Assert.That(valueOperand.StorageTZ, Is.False);
         }
 
         [Test]

--- a/Camlex.NET.UnitTests/Operands/DateTimeValueOperandTests.cs
+++ b/Camlex.NET.UnitTests/Operands/DateTimeValueOperandTests.cs
@@ -57,6 +57,33 @@ namespace CamlexNET.UnitTests.Operands
         }
 
         [Test]
+        public void test_THAT_datetime_value_with_storagetz_IS_rendered_to_caml_properly()
+        {
+            var dateTime = DateTime.Now;
+            var operand = new DateTimeValueOperand(dateTime, false, true);
+            var caml = operand.ToCaml().ToString();
+            Assert.That(caml, Is.EqualTo("<Value Type=\"DateTime\" StorageTZ=\"True\">" + dateTime.ToString("s") + "Z</Value>").Using(new CamlComparer()));
+        }
+
+        [Test]
+        public void test_THAT_datetime_value_without_storagetz_IS_rendered_to_caml_properly()
+        {
+            var dateTime = DateTime.Now;
+            var operand = new DateTimeValueOperand(dateTime, false, false);
+            var caml = operand.ToCaml().ToString();
+            Assert.That(caml, Is.EqualTo("<Value Type=\"DateTime\">" + dateTime.ToString("s") + "Z</Value>").Using(new CamlComparer()));
+        }
+
+        [Test]
+        public void test_THAT_datetime_value_with_includetimevalue_and_storagetz_IS_rendered_to_caml_properly()
+        {
+            var dateTime = DateTime.Now;
+            var operand = new DateTimeValueOperand(dateTime, true, true);
+            var caml = operand.ToCaml().ToString();
+            Assert.That(caml, Is.EqualTo("<Value Type=\"DateTime\" IncludeTimeValue=\"True\" StorageTZ=\"True\">" + dateTime.ToString("s") + "Z</Value>").Using(new CamlComparer()));
+        }
+
+        [Test]
         public void test_THAT_datetime_value_IS_successfully_created_from_valid_string()
         {
             var operand = new DateTimeValueOperand("02.01.2010 03:04:05", true);

--- a/Camlex.NET.UnitTests/ReverseEngeneering/Factories/ReOperandBuilderFromCamlTests.cs
+++ b/Camlex.NET.UnitTests/ReverseEngeneering/Factories/ReOperandBuilderFromCamlTests.cs
@@ -170,6 +170,10 @@ namespace CamlexNET.UnitTests.ReverseEngeneering.Factories
                 Is.EqualTo("<Value Type=\"DateTime\">2010-02-01T03:04:05Z</Value>"));
             Assert.That(b.CreateValueOperand(XmlHelper.Get("<Operation><Value Type=\"DateTime\" IncludeTimeValue=\"True\">2010-02-01T03:04:05Z</Value></Operation>"), false).ToCaml().ToString(),
                 Is.EqualTo("<Value Type=\"DateTime\" IncludeTimeValue=\"True\">2010-02-01T03:04:05Z</Value>"));
+            Assert.That(b.CreateValueOperand(XmlHelper.Get("<Operation><Value Type=\"DateTime\" StorageTZ=\"True\">2010-02-01T03:04:05Z</Value></Operation>"), false).ToCaml().ToString(),
+                Is.EqualTo("<Value Type=\"DateTime\" StorageTZ=\"True\">2010-02-01T03:04:05Z</Value>"));
+            Assert.That(b.CreateValueOperand(XmlHelper.Get("<Operation><Value Type=\"DateTime\" IncludeTimeValue=\"True\" StorageTZ=\"True\">2010-02-01T03:04:05Z</Value></Operation>"), false).ToCaml().ToString(),
+                Is.EqualTo("<Value Type=\"DateTime\" IncludeTimeValue=\"True\" StorageTZ=\"True\">2010-02-01T03:04:05Z</Value>"));
             Assert.That(b.CreateValueOperand(XmlHelper.Get("<Operation><Value Type=\"DateTime\"><Now /></Value></Operation>"), false).ToCaml().ToString(),
                 Is.EqualTo("<Value Type=\"DateTime\"><Now /></Value>").Using(new CamlComparer()));
             Assert.That(b.CreateValueOperand(XmlHelper.Get("<Operation><Value Type=\"DateTime\"><Today /></Value></Operation>"), false).ToCaml().ToString(),

--- a/Camlex.NET.UnitTests/ReverseEngeneering/Operands/DateTimeValueOperandTests.cs
+++ b/Camlex.NET.UnitTests/ReverseEngeneering/Operands/DateTimeValueOperandTests.cs
@@ -104,11 +104,28 @@ namespace CamlexNET.UnitTests.ReverseEngeneering.Operands
         }
 
         [Test]
+        public void test_THAT_native_operand_with_includetimevalue_and_storagetz_true_IS_conveted_to_expression_correctly()
+        {
+            var dt = new DateTime(2011, 4, 16, 22, 00, 00, 00);
+            var op = new DateTimeValueOperand(dt.ToString(), true, true);
+            var expr = op.ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo(dt + ".IncludeTimeValue(True)"));
+        }
+
+        [Test]
         public void test_THAT_string_based_operand_with_includetimevalue_IS_conveted_to_expression_correctly()
         {
             var op = new DateTimeValueOperand(Camlex.Now, true);
             var expr = op.ToExpression();
             Assert.That(expr.ToString(), Is.EqualTo("Convert(Convert(Camlex.Now)).IncludeTimeValue()"));
+        }
+
+        [Test]
+        public void test_THAT_string_based_operand_with_includetimevalue_and_storagetz_IS_conveted_to_expression_correctly()
+        {
+            var op = new DateTimeValueOperand(Camlex.Now, true, true);
+            var expr = op.ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo("Convert(Convert(Camlex.Now)).IncludeTimeValue(True)"));
         }
 
         [Test]

--- a/Camlex.NET.UnitTests/ReverseEngeneering/Operations/EqOperationTests.cs
+++ b/Camlex.NET.UnitTests/ReverseEngeneering/Operations/EqOperationTests.cs
@@ -130,6 +130,19 @@ namespace CamlexNET.UnitTests.ReverseEngeneering.Operations
         }
 
         [Test]
+        public void test_THAT_eq_operation_with_native_datetime_includetime_and_storagetz_IS_converted_to_expression_correctly()
+        {
+            var op1 = new FieldRefOperand("Modified");
+
+            var dt = new DateTime(2011, 4, 25, 19, 7, 00, 00);
+            var op2 = new DateTimeValueOperand(dt, true, true);
+            var op = new EqOperation(null, op1, op2);
+            Expression expr = op.ToExpression();
+            Assert.That(expr.ToString(),
+                        Is.EqualTo(string.Format("(Convert(x.get_Item(\"Modified\")) == {0}.IncludeTimeValue(True))", dt)));
+        }
+
+        [Test]
         public void test_THAT_eq_operation_with_string_based_datetime_IS_converted_to_expression_correctly()
         {
             var op1 = new FieldRefOperand("Modified");

--- a/Camlex.NET/Attributes.cs
+++ b/Camlex.NET/Attributes.cs
@@ -38,6 +38,7 @@ namespace CamlexNET
         public const string ID = "ID";
         public const string Type = "Type";
         public const string IncludeTimeValue = "IncludeTimeValue";
+        public const string StorageTZ = "StorageTZ";
         public const string OffsetDays = "OffsetDays";
         public const string Ascending = "Ascending";
         public const string Collapse = "Collapse";

--- a/Camlex.NET/DataTypes.cs
+++ b/Camlex.NET/DataTypes.cs
@@ -67,6 +67,8 @@ namespace CamlexNET
         {
             public DateTime IncludeTimeValue() { return this; }
 
+            public DateTime IncludeTimeValue(bool storageTZ) { return this; }
+
             public DateTime OffsetDays(int offsetDays) { return this; }
         }
         public class Error : BaseFieldType { }

--- a/Camlex.NET/ExtensionMethods.cs
+++ b/Camlex.NET/ExtensionMethods.cs
@@ -40,6 +40,7 @@ namespace CamlexNET
         /// <param name="dateTime">DateTime value</param>
         /// <returns>Not modified DateTime value</returns>
         public static DateTime IncludeTimeValue(this DateTime dateTime) { return dateTime; }
+        public static DateTime IncludeTimeValue(this DateTime dateTime, bool storageTZ) { return dateTime; }
         public static object PrimaryList(this object val, string primaryListAlias) { return val; }
         public static object ForeignList(this object val, string foreignListAlias) { return val; }
         public static object List(this object val, string foreignListAlias) { return val; }

--- a/Camlex.NET/Impl/Factories/OperandBuilder.cs
+++ b/Camlex.NET/Impl/Factories/OperandBuilder.cs
@@ -289,16 +289,29 @@ namespace CamlexNET.Impl.Factories
         private IOperand createValueOperand(Type type, object value, Expression expr)
         {
             bool includeTimeValue = ExpressionsHelper.IncludeTimeValue(expr);
+            var storageTZ = false;
+            if (includeTimeValue)
+            {
+                if (value.GetType() == typeof(DateTime) && ((MethodCallExpression)expr).Arguments.Count == 2)
+                {
+                    storageTZ = (bool)this.evaluateExpression(((MethodCallExpression)expr).Arguments[1]);
+                }
+                if (value.GetType() == typeof(string) && ((MethodCallExpression)expr).Arguments.Count == 1)
+                {
+                    storageTZ = (bool)this.evaluateExpression(((MethodCallExpression)expr).Arguments[0]);
+                }
+            }
+
             int offsetDays = 0;
             if (ExpressionsHelper.HasOffsetDays(expr))
             {
                 offsetDays = (int)this.evaluateExpression(((MethodCallExpression)expr).Arguments[0]);
             }
             bool isIntegerForUserId = ExpressionsHelper.IsIntegerForUserId(expr);
-            return CreateValueOperand(type, value, includeTimeValue, offsetDays, false, false, isIntegerForUserId);
+            return CreateValueOperand(type, value, includeTimeValue, offsetDays, storageTZ, false, false, isIntegerForUserId);
         }
 
-        internal static IOperand CreateValueOperand(Type type, object value, bool includeTimeValue, int offsetDays, bool parseExactDateTime, bool isComparisionOperation,
+        internal static IOperand CreateValueOperand(Type type, object value, bool includeTimeValue, int offsetDays, bool storageTZ, bool parseExactDateTime, bool isComparisionOperation,
             bool isIntegerForUserId)
         {
             // it is important to have check on NullValueOperand on 1st place
@@ -377,13 +390,13 @@ namespace CamlexNET.Impl.Factories
             {
                 if (value.GetType() == typeof(DateTime))
                 {
-                    return new DateTimeValueOperand((DateTime)value, includeTimeValue);
+                    return new DateTimeValueOperand((DateTime)value, includeTimeValue, storageTZ);
                 }
                 if (value.GetType() == typeof(string))
                 {
                     // for string based datetimes we need to specify additional parameter: should use ParseExact
                     // or simple Parse. Because from re it comes in sortable format ("s") and we need to use parse exact
-                    return new DateTimeValueOperand((string)value, includeTimeValue, parseExactDateTime, offsetDays);
+                    return new DateTimeValueOperand((string)value, includeTimeValue, parseExactDateTime, offsetDays, storageTZ);
                 }
             }
             // guid operand can be native or string based

--- a/Camlex.NET/Impl/Operands/DateTimeValueOperand.cs
+++ b/Camlex.NET/Impl/Operands/DateTimeValueOperand.cs
@@ -44,6 +44,7 @@ namespace CamlexNET.Impl.Operands
 
         public DateTimeValueMode Mode { get; set; }
         public bool IncludeTimeValue { get; set; }
+        public bool StorageTZ { get; set; }
         public int OffsetDays { get; set; }
 
         public DateTimeValueOperand(DateTime value, bool includeTimeValue) :
@@ -52,8 +53,20 @@ namespace CamlexNET.Impl.Operands
             IncludeTimeValue = includeTimeValue;
         }
 
+        public DateTimeValueOperand(DateTime value, bool includeTimeValue, bool storageTZ) :
+            base(typeof(DataTypes.DateTime), value)
+        {
+            IncludeTimeValue = includeTimeValue;
+            StorageTZ = storageTZ;
+        }
+
         public DateTimeValueOperand(string value, bool includeTimeValue) :
             this(value, includeTimeValue, false, 0)
+        {
+        }
+
+        public DateTimeValueOperand(string value, bool includeTimeValue, bool storageTZ) :
+            this(value, includeTimeValue, false, 0, storageTZ)
         {
         }
 
@@ -62,10 +75,22 @@ namespace CamlexNET.Impl.Operands
         {
         }
 
+        public DateTimeValueOperand(string value, bool includeTimeValue, int offsetDays, bool storageTZ) :
+            this(value, includeTimeValue, false, offsetDays, storageTZ)
+        {
+        }
+
         public DateTimeValueOperand(string value, bool includeTimeValue, bool parseExact, int offsetDays) :
+            this(value, includeTimeValue, parseExact, offsetDays, false)
+        {
+
+        }
+
+        public DateTimeValueOperand(string value, bool includeTimeValue, bool parseExact, int offsetDays, bool storageTZ) :
             base(typeof(DataTypes.DateTime), DateTime.MinValue)
         {
             IncludeTimeValue = includeTimeValue;
+            StorageTZ = storageTZ;
             OffsetDays = offsetDays;
 
             if (value == Camlex.Now) Mode = DateTimeValueMode.Now;
@@ -111,16 +136,22 @@ namespace CamlexNET.Impl.Operands
             {
                 dateTime = new XElement(Mode.ToString());
             }
-            
+
+            var attributes = new List<XAttribute>();
+            attributes.Add(new XAttribute(Attributes.Type, TypeName));
+
             if (IncludeTimeValue)
             {
-                return new XElement(Tags.Value,
-                                    new XAttribute(Attributes.Type, TypeName),
-                                    new XAttribute(Attributes.IncludeTimeValue, true.ToString()),
-                                    dateTime);
+                attributes.Add(new XAttribute(Attributes.IncludeTimeValue, true.ToString()));
             }
+
+            if (StorageTZ)
+            {
+                attributes.Add(new XAttribute(Attributes.StorageTZ, true.ToString()));
+            }
+
             return new XElement(Tags.Value,
-                                new XAttribute(Attributes.Type, TypeName),
+                                attributes,
                                 dateTime);
         }
 
@@ -134,12 +165,26 @@ namespace CamlexNET.Impl.Operands
             if (this.Mode == DateTimeValueMode.Native)
             {
                 var expr = Expression.Constant(this.Value);
+
                 if (this.IncludeTimeValue)
                 {
-                    var mi =
+                    if (StorageTZ)
+                    {
+                        var mi =
                         ReflectionHelper.GetExtensionMethods(typeof(Camlex).Assembly, typeof(DateTime)).FirstOrDefault(
-                            m => m.Name == ReflectionHelper.IncludeTimeValue);
-                    return Expression.Call(mi, expr);
+                            m => m.Name == ReflectionHelper.IncludeTimeValue && m.GetParameters().Count() == 2);
+
+                        return Expression.Call(mi, expr, Expression.Constant(StorageTZ));
+                    }
+                    else
+                    {
+                        var mi =
+                        ReflectionHelper.GetExtensionMethods(typeof(Camlex).Assembly, typeof(DateTime)).FirstOrDefault(
+                            m => m.Name == ReflectionHelper.IncludeTimeValue && m.GetParameters().Count() == 1);
+
+                        return Expression.Call(mi, expr);
+                    }
+
                 }
                 else
                 {
@@ -151,6 +196,7 @@ namespace CamlexNET.Impl.Operands
                 var val = this.getExpressionByMode(this.Mode);
                 var expr = Expression.Convert(Expression.Convert(val, typeof(BaseFieldType)),
                                           typeof(DataTypes.DateTime));
+
                 if (Mode == DateTimeValueMode.Today && OffsetDays != 0)
                 {
                     var mi =
@@ -159,11 +205,27 @@ namespace CamlexNET.Impl.Operands
                 }
                 else if (this.IncludeTimeValue)
                 {
-                    var mi =
-                        typeof(DataTypes.DateTime).GetMethod(ReflectionHelper.IncludeTimeValue);
-                    return Expression.Call(expr, mi);
+                    if (StorageTZ)
+                    {
+                        var mi =
+                        typeof(DataTypes.DateTime).GetMethods().FirstOrDefault(
+                           m => m.Name == ReflectionHelper.IncludeTimeValue && m.GetParameters().Count() == 1);
+
+                        return Expression.Call(expr, mi, Expression.Constant(StorageTZ));
+                    }
+                    else
+                    {
+                        var mi =
+                        typeof(DataTypes.DateTime).GetMethods().FirstOrDefault(
+                           m => m.Name == ReflectionHelper.IncludeTimeValue && m.GetParameters().Count() == 0);
+                        
+                        return Expression.Call(expr, mi);
+                    }
                 }
-                return expr;
+                else
+                {
+                    return expr;
+                }
             }
         }
 

--- a/Camlex.NET/Impl/ReverseEngeneering/Caml/Factories/ReOperandBuilderFromCaml.cs
+++ b/Camlex.NET/Impl/ReverseEngeneering/Caml/Factories/ReOperandBuilderFromCaml.cs
@@ -255,6 +255,18 @@ namespace CamlexNET.Impl.ReverseEngeneering.Caml.Factories
                 }
             }
 
+            bool storageTZ = false;
+            var storageTZAttr = valueElement.Attributes().FirstOrDefault(a => a.Name == Attributes.StorageTZ);
+            if (storageTZAttr != null)
+            {
+                if (!bool.TryParse(storageTZAttr.Value, out storageTZ))
+                {
+                    throw new CamlAnalysisException(
+                        string.Format(
+                            "Can't create value operand: attribute '{0}' has incorrect value '{1}'. It should have boolean value", storageTZAttr.Name, storageTZAttr.Value));
+                }
+            }
+
             int offsetDays = 0;            
             string value = valueElement.Value;
             if (type == typeof(DataTypes.DateTime) && valueElement.Descendants().Count() == 1)
@@ -281,7 +293,7 @@ namespace CamlexNET.Impl.ReverseEngeneering.Caml.Factories
             // currently only string-based value operand will be returned
             // todo: add support of native operands here (see OperandBuilder.CreateValueOperand() for details)
             return OperandBuilder.CreateValueOperand(
-                convertedType, value, includeTimeValue, offsetDays, true, isComparision, isIntegerForUserId);
+                convertedType, value, includeTimeValue, offsetDays, storageTZ, true, isComparision, isIntegerForUserId);
         }
 
         private Type convertToNativeIfPossible(Type type)


### PR DESCRIPTION
New overload for IncludeTimeValue added which will generate StorageTZ="True" for the CAML Query

```csharp
e => e["DateField"] > ((DataTypes.DateTime)dateTime).IncludeTimeValue(true)
```
```xml
<Where>
  <Gt>
    <FieldRef Name='DateField' />
    <Value Type='DateTime' IncludeTimeValue='TRUE' StorageTZ='TRUE'>
      2012-10-24T21:30:46Z
    </Value>
  </Gt>
</Where>
```