### PR TITLE
Fix Binary Operation for TextValueOperand

### DIFF
--- a/Camlex.NET.UnitTests/ReverseEngeneering/Operations/GeqOperationTests.cs
+++ b/Camlex.NET.UnitTests/ReverseEngeneering/Operations/GeqOperationTests.cs
@@ -59,5 +59,15 @@ namespace CamlexNET.UnitTests.ReverseEngeneering.Operations
             Expression expr = op.ToExpression();
             Assert.That(expr.ToString(), Is.EqualTo("(Convert(x.get_Item(\"Count\")) >= 1)"));
         }
+
+        [Test]
+        public void test_THAT_geq_operation_with_string_IS_converted_to_expression_correctly()
+        {
+            var op1 = new FieldRefOperand("Title");
+            var op2 = new TextValueOperand("Test");
+            var op = new GeqOperation(null, op1, op2);
+            Expression expr = op.ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo("(x.get_Item(\"Title\") >= Convert(Convert(\"Test\")))"));
+        }
     }
 }

--- a/Camlex.NET.UnitTests/ReverseEngeneering/Operations/GtOperationTests.cs
+++ b/Camlex.NET.UnitTests/ReverseEngeneering/Operations/GtOperationTests.cs
@@ -59,5 +59,15 @@ namespace CamlexNET.UnitTests.ReverseEngeneering.Operations
             Expression expr = op.ToExpression();
             Assert.That(expr.ToString(), Is.EqualTo(result));
         }
+
+        [Test]
+        public void test_THAT_gt_operation_with_string_IS_converted_to_expression_correctly()
+        {
+            var op1 = new FieldRefOperand("Title");
+            var op2 = new TextValueOperand("Test");
+            var op = new GtOperation(null, op1, op2);
+            Expression expr = op.ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo("(x.get_Item(\"Title\") > Convert(Convert(\"Test\")))"));
+        }
     }
 }

--- a/Camlex.NET.UnitTests/ReverseEngeneering/Operations/LeqOperationTests.cs
+++ b/Camlex.NET.UnitTests/ReverseEngeneering/Operations/LeqOperationTests.cs
@@ -25,9 +25,8 @@
 // -----------------------------------------------------------------------------
 #endregion
 using System;
+using System.Linq.Expressions;
 using CamlexNET.Impl.Operands;
-using CamlexNET.Impl.Operations.Eq;
-using CamlexNET.Impl.Operations.Geq;
 using CamlexNET.Impl.Operations.Leq;
 using NUnit.Framework;
 
@@ -44,6 +43,16 @@ namespace CamlexNET.UnitTests.ReverseEngeneering.Operations
             var op = new LeqOperation(null, op1, op2);
             var expr = op.ToExpression();
             Assert.That(expr.ToString(), Is.EqualTo("(Convert(x.get_Item(\"Count\")) <= 1)"));
+        }
+
+        [Test]
+        public void test_THAT_leq_operation_with_string_IS_converted_to_expression_correctly()
+        {
+            var op1 = new FieldRefOperand("Title");
+            var op2 = new TextValueOperand("Test");
+            var op = new LeqOperation(null, op1, op2);
+            Expression expr = op.ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo("(x.get_Item(\"Title\") <= Convert(Convert(\"Test\")))"));
         }
     }
 }

--- a/Camlex.NET.UnitTests/ReverseEngeneering/Operations/LtOperationTests.cs
+++ b/Camlex.NET.UnitTests/ReverseEngeneering/Operations/LtOperationTests.cs
@@ -60,5 +60,15 @@ namespace CamlexNET.UnitTests.ReverseEngeneering.Operations
             Expression expr = op.ToExpression();
             Assert.That(expr.ToString(), Is.EqualTo("(Convert(x.get_Item(\"Count\")) < 1)"));
         }
+
+        [Test]
+        public void test_THAT_lt_operation_with_string_IS_converted_to_expression_correctly()
+        {
+            var op1 = new FieldRefOperand("Title");
+            var op2 = new TextValueOperand("Test");
+            var op = new LtOperation(null, op1, op2);
+            Expression expr = op.ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo("(x.get_Item(\"Title\") < Convert(Convert(\"Test\")))"));
+        }
     }
 }

--- a/Camlex.NET.UnitTests/ReverseEngeneering/ReQueryTests.cs
+++ b/Camlex.NET.UnitTests/ReverseEngeneering/ReQueryTests.cs
@@ -353,5 +353,73 @@ namespace CamlexNET.UnitTests.ReverseEngeneering
             var expr = Camlex.QueryFromString(xml).ToExpression();
             Assert.That(expr.ToString(), Is.EqualTo("Query().Where(x => (Convert(x.get_Item(\"Created\")) > 5/18/2021 5:31:18 PM.IncludeTimeValue(True)))"));
         }
+
+        [Test]
+        public void test_THAT_expression_with_string_greater_IS_translated_successfully()
+        {
+            var xml =
+                "<Query>" +
+                "  <Where>" +
+                "    <Gt>" +
+                "      <FieldRef Name=\"Foo\" />" +
+                "      <Value Type=\"Text\">Test</Value>" +
+                "    </Gt>" +
+                "  </Where>" +
+                "</Query>";
+
+            var expr = Camlex.QueryFromString(xml).ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo("Query().Where(x => (x.get_Item(\"Foo\") > Convert(Convert(\"Test\"))))"));
+        }
+
+        [Test]
+        public void test_THAT_expression_with_string_greaterORequals_IS_translated_successfully()
+        {
+            var xml =
+                "<Query>" +
+                "  <Where>" +
+                "    <Geq>" +
+                "      <FieldRef Name=\"Foo\" />" +
+                "      <Value Type=\"Text\">Test</Value>" +
+                "    </Geq>" +
+                "  </Where>" +
+                "</Query>";
+
+            var expr = Camlex.QueryFromString(xml).ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo("Query().Where(x => (x.get_Item(\"Foo\") >= Convert(Convert(\"Test\"))))"));
+        }
+
+        [Test]
+        public void test_THAT_expression_with_string_less_IS_translated_successfully()
+        {
+            var xml =
+                "<Query>" +
+                "  <Where>" +
+                "    <Lt>" +
+                "      <FieldRef Name=\"Foo\" />" +
+                "      <Value Type=\"Text\">Test</Value>" +
+                "    </Lt>" +
+                "  </Where>" +
+                "</Query>";
+
+            var expr = Camlex.QueryFromString(xml).ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo("Query().Where(x => (x.get_Item(\"Foo\") < Convert(Convert(\"Test\"))))"));
+        }
+
+        [Test]
+        public void test_THAT_expression_with_string_lessORequals_IS_translated_successfully()
+        {
+            var xml =
+                "<Query>" +
+                "  <Where>" +
+                "    <Leq>" +
+                "      <FieldRef Name=\"Foo\" />" +
+                "      <Value Type=\"Text\">Test</Value>" +
+                "    </Leq>" +
+                "  </Where>" +
+                "</Query>";
+
+            var expr = Camlex.QueryFromString(xml).ToExpression();
+            Assert.That(expr.ToString(), Is.EqualTo("Query().Where(x => (x.get_Item(\"Foo\") <= Convert(Convert(\"Test\"))))"));
+        }
     }
 }

--- a/Camlex.NET/Impl/BinaryOperationBase.cs
+++ b/Camlex.NET/Impl/BinaryOperationBase.cs
@@ -87,6 +87,7 @@ namespace CamlexNET.Impl
         protected virtual Type getValueOperandType()
         {
             var valueOperandExpr = this.valueOperand.ToExpression();
+
             if (valueOperandExpr is ConstantExpression)
             {
                 return ((ConstantExpression)valueOperandExpr).Value.GetType();

--- a/Camlex.NET/Impl/Operations/Geq/GeqOperation.cs
+++ b/Camlex.NET/Impl/Operations/Geq/GeqOperation.cs
@@ -29,6 +29,7 @@ using System;
 using System.Linq.Expressions;
 using System.Xml.Linq;
 using CamlexNET.Impl.Factories;
+using CamlexNET.Impl.Operands;
 using CamlexNET.Interfaces;
 
 namespace CamlexNET.Impl.Operations.Geq
@@ -54,9 +55,17 @@ namespace CamlexNET.Impl.Operations.Geq
             var fieldRef = this.getFieldRefOperandExpression();
             var value = this.getValueOperandExpression();
 
-            if (!value.Type.IsSubclassOf(typeof(BaseFieldTypeWithOperators)))
+            if (!value.Type.IsSubclassOf(typeof(BaseFieldTypeWithOperators)) && this.valueOperand.GetType() != typeof(TextValueOperand))
             {
                 return Expression.GreaterThanOrEqual(fieldRef, value);
+            }
+            else if (this.valueOperand.GetType() == typeof(TextValueOperand))
+            {
+                var methodInfo = typeof(BaseFieldTypeWithOperators).GetMethod(ReflectionHelper.GreaterThanOrEqualMethodName);
+
+                var fieldRefExpr = this.fieldRefOperand.ToExpression();
+                var convertedValue = Expression.Convert(value, typeof(BaseFieldType));
+                return Expression.GreaterThanOrEqual(fieldRefExpr, Expression.Convert(convertedValue, typeof(DataTypes.Text)), false, methodInfo);
             }
             else
             {

--- a/Camlex.NET/Impl/Operations/Gt/GtOperation.cs
+++ b/Camlex.NET/Impl/Operations/Gt/GtOperation.cs
@@ -27,8 +27,10 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Xml.Linq;
 using CamlexNET.Impl.Factories;
+using CamlexNET.Impl.Operands;
 using CamlexNET.Interfaces;
 
 namespace CamlexNET.Impl.Operations.Gt
@@ -54,9 +56,17 @@ namespace CamlexNET.Impl.Operations.Gt
             var fieldRef = this.getFieldRefOperandExpression();
             var value = this.getValueOperandExpression();
 
-            if (!value.Type.IsSubclassOf(typeof(BaseFieldTypeWithOperators)))
+            if (!value.Type.IsSubclassOf(typeof(BaseFieldTypeWithOperators)) && this.valueOperand.GetType() != typeof(TextValueOperand))
             {
                 return Expression.GreaterThan(fieldRef, value);
+            }
+            else if (this.valueOperand.GetType() == typeof(TextValueOperand))
+            {
+                var methodInfo = typeof(BaseFieldTypeWithOperators).GetMethod(ReflectionHelper.GreaterThanMethodName);
+
+                var fieldRefExpr = this.fieldRefOperand.ToExpression();
+                var convertedValue = Expression.Convert(value, typeof(BaseFieldType));
+                return Expression.GreaterThan(fieldRefExpr, Expression.Convert(convertedValue, typeof(DataTypes.Text)), false, methodInfo);
             }
             else
             {

--- a/Camlex.NET/Impl/Operations/Leq/LeqOperation.cs
+++ b/Camlex.NET/Impl/Operations/Leq/LeqOperation.cs
@@ -29,6 +29,7 @@ using System;
 using System.Linq.Expressions;
 using System.Xml.Linq;
 using CamlexNET.Impl.Factories;
+using CamlexNET.Impl.Operands;
 using CamlexNET.Interfaces;
 
 namespace CamlexNET.Impl.Operations.Leq
@@ -54,9 +55,17 @@ namespace CamlexNET.Impl.Operations.Leq
             var fieldRef = this.getFieldRefOperandExpression();
             var value = this.getValueOperandExpression();
 
-            if (!value.Type.IsSubclassOf(typeof(BaseFieldTypeWithOperators)))
+            if (!value.Type.IsSubclassOf(typeof(BaseFieldTypeWithOperators)) && this.valueOperand.GetType() != typeof(TextValueOperand))
             {
                 return Expression.LessThanOrEqual(fieldRef, value);
+            }
+            else if (this.valueOperand.GetType() == typeof(TextValueOperand))
+            {
+                var methodInfo = typeof(BaseFieldTypeWithOperators).GetMethod(ReflectionHelper.LessThanOrEqualMethodName);
+
+                var fieldRefExpr = this.fieldRefOperand.ToExpression();
+                var convertedValue = Expression.Convert(value, typeof(BaseFieldType));
+                return Expression.LessThanOrEqual(fieldRefExpr, Expression.Convert(convertedValue, typeof(DataTypes.Text)), false, methodInfo);
             }
             else
             {

--- a/Camlex.NET/Impl/Operations/Lt/LtOperation.cs
+++ b/Camlex.NET/Impl/Operations/Lt/LtOperation.cs
@@ -29,6 +29,7 @@ using System;
 using System.Linq.Expressions;
 using System.Xml.Linq;
 using CamlexNET.Impl.Factories;
+using CamlexNET.Impl.Operands;
 using CamlexNET.Interfaces;
 
 namespace CamlexNET.Impl.Operations.Lt
@@ -54,9 +55,17 @@ namespace CamlexNET.Impl.Operations.Lt
             var fieldRef = this.getFieldRefOperandExpression();
             var value = this.getValueOperandExpression();
 
-            if (!value.Type.IsSubclassOf(typeof(BaseFieldTypeWithOperators)))
+            if (!value.Type.IsSubclassOf(typeof(BaseFieldTypeWithOperators)) && this.valueOperand.GetType() != typeof(TextValueOperand))
             {
                 return Expression.LessThan(fieldRef, value);
+            }
+            else if (this.valueOperand.GetType() == typeof(TextValueOperand))
+            {
+                var methodInfo = typeof(BaseFieldTypeWithOperators).GetMethod(ReflectionHelper.LessThanMethodName);
+
+                var fieldRefExpr = this.fieldRefOperand.ToExpression();
+                var convertedValue = Expression.Convert(value, typeof(BaseFieldType));
+                return Expression.LessThan(fieldRefExpr, Expression.Convert(convertedValue, typeof(DataTypes.Text)), false, methodInfo);
             }
             else
             {


### PR DESCRIPTION
This implementation solves the reverse engineering of a binary operator with text fields so that no exception is thrown. Example Query:
<Query><Where><Gt><FieldRef Name="Foo" /><Value Type="Text>Test</Value></Gt></Where></Query>